### PR TITLE
[refactor]: SSR에서 토큰 리프레시 처리, 클라이언트 초기화 간소화

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,18 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */
-
+  // rewrites: async () => {
+  //   return [
+  //     {
+  //       source: `/api/v1/:path*`, //frontend api url
+  //       destination: `${process.env.CHZZK_API_URL}/:path*`,
+  //     },
+  //     {
+  //       source: `/api/streamer/:path*`, //frontend api url
+  //       destination: `${process.env.FRONT_API_URL}/:path*`, // 예: https://chit-seven.vercel.app
+  //     },
+  //   ];
+  // },
   webpack: (config) => {
     const fileLoaderRule = config.module.rules.find((rule: any) => rule.test?.test?.('.svg'));
 

--- a/src/provider/AuthInitializer.tsx
+++ b/src/provider/AuthInitializer.tsx
@@ -1,9 +1,20 @@
 import { cookies } from 'next/headers';
 import AuthInitializerClient from './AuthInitializerClient';
+import { createSSRClient } from '@/services/_axios/ssrClient';
 
 export default async function AuthInitializer() {
   const cookieStore = await cookies();
   const REFRESH_TOKEN = cookieStore.get('REFRESH_TOKEN')?.value;
 
-  return <AuthInitializerClient refreshToken={REFRESH_TOKEN ?? null} />;
+  const ssrClient = createSSRClient(`REFRESH_TOKEN=${REFRESH_TOKEN}`); // 👈 쿠키 직접 전달
+
+  try {
+    const response = await ssrClient.post('/auth/refresh'); // 원하는 API 호출
+    const accessToken = response.data?.data;
+
+    return <AuthInitializerClient accessToken={accessToken} refreshToken={REFRESH_TOKEN ?? null} />;
+  } catch (err) {
+    console.error('🔴 refresh 실패:', err);
+    return <AuthInitializerClient accessToken={null} refreshToken={null} />;
+  }
 }

--- a/src/services/_axios/ssrClient.ts
+++ b/src/services/_axios/ssrClient.ts
@@ -1,0 +1,12 @@
+// utils/ssrClient.ts
+import axios from 'axios';
+
+export const createSSRClient = (cookie: string | undefined) => {
+  return axios.create({
+    baseURL: process.env.NEXT_PUBLIC_API_URL,
+    headers: {
+      Cookie: cookie || '',
+    },
+    withCredentials: true,
+  });
+};

--- a/src/services/common/common.ts
+++ b/src/services/common/common.ts
@@ -29,11 +29,7 @@ export const refreshAccessToken = async (): Promise<
   Result<ApiResponse<RefreshAccessTokenResponse>>
 > => {
   try {
-    const response = await sessionClient.post(
-      `${AUTH_URLS.refresh}`,
-      {},
-      { withCredentials: true },
-    );
+    const response = await sessionClient.post(`${AUTH_URLS.refresh}`);
 
     console.log('debug : refreshToken 재발급');
     console.log(response.data);


### PR DESCRIPTION
- 서버에서 REFRESH_TOKEN 쿠키로 accessToken 발급
- 클라이언트는 API 호출 없이 상태만 초기화
- 중복된 refreshAccessToken 호출 제거

## 📝 작업 내용

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 코드 리팩터링
- [ ] 스타일 수정
- [ ] 문서 업데이트
- [ ] 기타 (설명):

